### PR TITLE
Add edit button to list page for owner

### DIFF
--- a/Client/Pages/Public.razor
+++ b/Client/Pages/Public.razor
@@ -78,6 +78,15 @@
               </div>
             </div>
           </div>
+          @if (IsOwner)
+          {
+            <div class="buttons is-right">
+              <button class="button is-primary" @onclick="NavigateToEdit">
+                <span class="icon"><i class="fas fa-edit"></i></span>
+                <span>Edit</span>
+              </button>
+            </div>
+          }
           <div class="has-text-centered @(ShowQr ? "" : "is-hidden")">
             <QrCodeItem Url="@($"https://theurlist.com/{vanityUrl}")"></QrCodeItem>
           </div>
@@ -116,6 +125,7 @@
 
   private bool LoadingList { get; set; } = false;
   private bool ShowQr { get; set; } = false;
+  private bool IsOwner { get; set; } = false;
 
   private LinkBundle linkBundle { get; set; } = new LinkBundle();
   protected override async Task OnInitializedAsync()
@@ -126,6 +136,11 @@
 
       var response = await Http.GetFromJsonAsync<LinkBundle>($"api/links/{vanityUrl}");
       linkBundle = response ?? new LinkBundle();
+
+      if (StateContainer.User?.ClientPrincipal?.UserId == linkBundle.UserId)
+      {
+        IsOwner = true;
+      }
     }
     catch (Exception ex)
     {
@@ -145,5 +160,11 @@
     StateContainer.LinkBundle = new LinkBundle();
     StateContainer.LinkBundle.VanityUrl = vanityUrl;
     NavigationManager.NavigateTo($"/s/new/");
+  }
+
+  private void NavigateToEdit()
+  {
+    StateContainer.LinkBundle = linkBundle;
+    NavigationManager.NavigateTo("/s/edit");
   }
 }


### PR DESCRIPTION
Fixes #90

Add an edit button for the owner of the list on the list page.

* Add an edit button in `Client/Pages/Public.razor` that is visible only to the owner of the list.
* Add logic to check if the current user is the owner of the list by comparing the user ID with the `linkBundle.UserId`.
* Implement navigation to the edit page with the correct `LinkBundle` when the edit button is clicked.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/the-urlist/blazor-static-web-apps/pull/91?shareId=deea9198-0250-449c-9bc8-579bcd4fc805).